### PR TITLE
Fix border-colour/font-colour issues

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -37,7 +37,7 @@
 					"color": "var(--color-muted-foreground)",
 					"name": "Muted Foreground"
 				},
-				{ "slug": "border", "color": "var(--color-border)", "name": "Border" },
+				{ "slug": "gw-border", "color": "var(--color-border)", "name": "Border" },
 				{ "slug": "input", "color": "var(--color-input)", "name": "Input" },
 				{ "slug": "ring", "color": "var(--color-ring)", "name": "Ring" }
 			]


### PR DESCRIPTION
Naming a colour "border" in theme.json was clashing with the border colour.  

An element with a border colour is given the class `has-border-color`, but because there is a colour called "border" in theme.json, it is also colouring the text according to what it thinks this colour is.  

Renaming the colour `gw-border` for now and we can revisit this later.  