### PR TITLE
Button styles 4312

### DIFF
--- a/assets/css/globals/_buttons.scss
+++ b/assets/css/globals/_buttons.scss
@@ -1,6 +1,8 @@
-@use "sass:color";
+// Define layer order
+@layer wp-defaults, wp-components, theme-overrides, utilities;
+//@layer global, elements, components, utilities;
 
-// Custom properties that need to be defined in CSS (since they're not able to be defined in theme.json)
+// This contains custom properties that are not supported in the theme.json schema
 :root {
 	--btn-width: 12rem;
 	--btn-height: auto;
@@ -11,96 +13,211 @@
 	--btn-border-width: 2px;
 }
 
-// Button block override - Fill style (default)
-.wp-block-button {
-	.wp-block-button__link {
-		// theme.json handles: background-color, font-size, line-height, padding, border-radius, color
-		min-width: var(--btn-width);
-		height: var(--btn-height);
-		gap: var(--btn-gap);
-		opacity: 1;
-		border: none;
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		text-decoration: none;
-		transition:
-			background-color 0.3s ease,
-			color 0.3s ease,
-			border-color 0.3s ease;
-		// Performance hint - tells browser to optimize transititons/animations in advance
-		will-change: background-color, color, border-color;
+@layer theme-overrides {
+	// Fill button styles (default)
+	.wp-block-button {
+		.wp-block-button__link {
+			// theme.json handles: background-color, font-size, line-height, padding, border-radius, color
+			@apply h-auto min-w-[var(--btn-width)] gap-[10px];
+			@apply inline-flex items-center justify-center no-underline;
+			@apply transition-all duration-200 ease-in-out;
+			@apply will-change-[background-color,color,border-color];
 
-		// Hover state
-		&:hover {
-			background-color: var(--default-primary-accent) !important;
+			// Ensure transitions work everywhere
+			transition:
+				background-color 0.2s ease,
+				color 0.3s ease,
+				border-color 0.2s ease,
+				transform 0.1s ease;
+
+			// Hover state
+			&:hover {
+				background-color: var(--default-primary-accent);
+			}
+
+			// Focus state (keyboard users)
+			&:focus,
+			&:focus-visible {
+				@apply outline-[3px] outline-offset-2 outline-solid;
+				outline-color: #ffb900;
+			}
+
+			// Active (pressed) feedback
+			&:active {
+				@apply scale-[0.97];
+			}
+
+			// Disabled state
+			&[aria-disabled="true"] {
+				@apply pointer-events-none opacity-60;
+			}
 		}
 
-		// Focus state (keyboard users)
-		&:focus,
-		&:focus-visible {
-			outline: 3px solid var(--default-primary-accent);
-			outline-offset: 2px;
-		}
+		// Outline button style override
+		&.is-style-outline .wp-block-button__link {
+			@apply border-solid bg-transparent opacity-100;
+			@apply h-[var(--outline-btn-height)] w-[var(--outline-btn-width)] gap-[var(--outline-btn-gap)];
+			@apply transition-all duration-300 ease-in-out;
+			@apply will-change-[background-color,color,border-color];
 
-		// Active (pressed) feedback
-		&:active {
-			transform: scale(0.97);
-		}
+			background-color: transparent;
+			border: var(--btn-border-width) solid #ffb900;
+			color: var(--default-primary);
 
-		// Disabled state
-		&[aria-disabled="true"] {
-			opacity: 0.6;
-			pointer-events: none;
+			// Override theme.json padding for outline buttons
+			padding: var(--spacing-3-5) var(--spacing-6);
+			transition:
+				background-color 0.3s ease,
+				color 0.3s ease,
+				border-color 0.3s ease,
+				transform 0.15s ease;
+
+			&:hover {
+				background-color: var(--default-primary);
+				color: var(--default-background);
+				border-color: var(--default-primary-accent);
+			}
+
+			&:focus,
+			&:focus-visible {
+				@apply outline-[3px] outline-offset-2 outline-solid;
+				outline-color: #ffb900;
+			}
+
+			&:active {
+				@apply scale-[0.97];
+			}
+
+			&[aria-disabled="true"] {
+				@apply pointer-events-none opacity-60;
+			}
 		}
 	}
 
-	// Outline button style override
-	&.is-style-outline .wp-block-button__link {
-		background-color: transparent !important;
-		border: var(--btn-border-width) solid var(--default-primary);
-		color: var(--default-primary) !important;
-		width: var(--outline-btn-width);
-		height: var(--outline-btn-height);
-		gap: var(--outline-btn-gap);
-		opacity: 1;
-		// Override theme.json padding for outline buttons
-		padding: var(--spacing-3-5) var(--spacing-6) !important;
-		transition:
-			background-color 0.3s ease,
-			color 0.3s ease,
-			border-color 0.3s ease;
-		will-change: background-color, color, border-color;
+	// Editor-specific styles
+	.editor-styles-wrapper .wp-block-button {
+		.wp-block-button__link {
+			// Ensure editor styles match frontend
+			@apply h-auto min-w-[var(--btn-width)] gap-[10px];
+			@apply transition-all duration-300 ease-in-out;
 
-		&:hover {
-			background-color: var(--default-primary) !important;
-			color: var(--default-background) !important;
-			border-color: var(--default-primary-accent);
+			&:hover {
+				background-color: var(--default-primary-accent);
+			}
+
+			&:active {
+				@apply scale-[0.97];
+			}
 		}
 
-		&:focus,
-		&:focus-visible {
-			outline: 3px solid var(--default-primary-accent);
-			outline-offset: 2px;
-		}
+		&.is-style-outline .wp-block-button__link {
+			@apply bg-transparent;
+			background-color: transparent;
+			border: var(--btn-border-width) solid var(--default-primary);
+			color: var(--default-primary);
 
-		&:active {
-			transform: scale(0.97);
+			&:hover {
+				background-color: var(--default-primary);
+				color: var(--default-background);
+			}
 		}
+	}
 
-		&[aria-disabled="true"] {
-			opacity: 0.6;
-			pointer-events: none;
+	// Block editor specific styles
+	.block-editor-block-list__layout .wp-block-button {
+		.wp-block-button__link {
+			@apply transition-all duration-300 ease-in-out;
+
+			&:hover {
+				background-color: var(--default-primary-accent);
+			}
 		}
 	}
 }
 
+@layer utilities {
+	.btn-no-animation {
+		@apply transition-none;
+		transform: none !important;
+	}
+
+	.btn-full-width {
+		@apply w-full;
+		width: 100%;
+	}
+}
+
 // Accessibility: High-contrast support (Windows forced-colors)
+// This stays outside layers as it's a media query override
 @media (forced-colors: active) {
 	.wp-block-button__link,
 	.wp-block-button.is-style-outline .wp-block-button__link {
-		border: 1px solid ButtonText;
-		color: ButtonText !important;
-		background: ButtonFace !important;
+		@apply border border-solid;
+		border-color: ButtonText !important;
+		color: ButtonText;
+		background: ButtonFace;
+	}
+}
+
+// Print styles
+@media print {
+	.wp-block-button__link {
+		@apply border border-solid border-black bg-transparent text-black;
+		@apply no-underline;
+
+		&::after {
+			content: " (" attr(href) ")";
+			@apply text-xs text-gray-600;
+		}
+	}
+}
+
+// Reduced motion support
+@media (prefers-reduced-motion: reduce) {
+	.wp-block-button__link {
+		@apply transition-none;
+		transition: none;
+
+		&:active {
+			@apply scale-100; // No scale animation for reduced motion
+		}
+	}
+}
+
+// Fallback for browsers that don't support @layer
+@supports not (selector(layer())) {
+	// High specificity fallback styles
+	.wp-site-blocks .wp-block-button .wp-block-button__link,
+	.editor-styles-wrapper .wp-block-button .wp-block-button__link {
+		min-width: var(--btn-width);
+		height: auto;
+		gap: 10px;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		text-decoration: none;
+		transition: all 0.3s ease;
+
+		&:hover {
+			background-color: var(--default-primary-accent);
+		}
+
+		&:active {
+			transform: scale(0.97);
+		}
+	}
+
+	.wp-site-blocks .wp-block-button.is-style-outline .wp-block-button__link,
+	.editor-styles-wrapper
+		.wp-block-button.is-style-outline
+		.wp-block-button__link {
+		background-color: transparent;
+		border: var(--btn-border-width) solid var(--default-primary);
+		color: var(--default-primary);
+
+		&:hover {
+			background-color: var(--default-primary);
+			color: var(--default-background);
+		}
 	}
 }

--- a/assets/css/globals/_buttons.scss
+++ b/assets/css/globals/_buttons.scss
@@ -18,7 +18,7 @@
 	.wp-block-button {
 		.wp-block-button__link {
 			// theme.json handles: background-color, font-size, line-height, padding, border-radius, color
-			@apply h-auto min-w-[var(--btn-width)] gap-[10px];
+			@apply h-auto min-w-(--btn-width) gap-[10px];
 			@apply inline-flex items-center justify-center no-underline;
 			@apply transition-all duration-200 ease-in-out;
 			@apply will-change-[background-color,color,border-color];
@@ -56,7 +56,7 @@
 		// Outline button style override
 		&.is-style-outline .wp-block-button__link {
 			@apply border-solid bg-transparent opacity-100;
-			@apply h-[var(--outline-btn-height)] w-[var(--outline-btn-width)] gap-[var(--outline-btn-gap)];
+			@apply h-(--outline-btn-height) w-(--outline-btn-width) gap-(--outline-btn-gap);
 			@apply transition-all duration-300 ease-in-out;
 			@apply will-change-[background-color,color,border-color];
 
@@ -98,7 +98,7 @@
 	.editor-styles-wrapper .wp-block-button {
 		.wp-block-button__link {
 			// Ensure editor styles match frontend
-			@apply h-auto min-w-[var(--btn-width)] gap-[10px];
+			@apply h-auto min-w-(--btn-width) gap-[10px];
 			@apply transition-all duration-300 ease-in-out;
 
 			&:hover {

--- a/assets/css/globals/_buttons.scss
+++ b/assets/css/globals/_buttons.scss
@@ -69,6 +69,7 @@
 		@apply bg-transparent;
 		border-width: var(--btn-border-width);
 		border-color: transparent;
+		color: var(--default-primary);
 
 		&:hover {
 			background-color: var(--ghost-hover-bg);

--- a/assets/css/globals/_buttons.scss
+++ b/assets/css/globals/_buttons.scss
@@ -1,0 +1,96 @@
+@use "sass:color";
+
+// Custom properties that need to be defined in CSS (since they're not able to be defined in theme.json)
+:root {
+	--btn-width: 12rem;
+	--btn-height: auto;
+	--btn-gap: 10px;
+	--outline-btn-width: 208px;
+	--outline-btn-height: 56px;
+	--outline-btn-gap: 16px;
+	--btn-border-width: 2px;
+}
+
+// Button block override - Fill style (default)
+.wp-block-button {
+	.wp-block-button__link {
+		// theme.json handles: background-color, font-size, line-height, padding, border-radius, color
+		min-width: var(--btn-width);
+		height: var(--btn-height);
+		gap: var(--btn-gap);
+		opacity: 1;
+		border: none;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		text-decoration: none;
+		transition:
+			background-color 0.3s ease,
+			color 0.3s ease,
+			border-color 0.3s ease;
+		// Performance hint - tells browser to optimize transititons/animations in advance
+		will-change: background-color, color, border-color;
+
+		// Hover state
+		&:hover {
+			background-color: var(--default-primary-accent) !important;
+		}
+
+		// Focus state (keyboard users)
+		&:focus,
+		&:focus-visible {
+			outline: 3px solid var(--default-primary-accent);
+			outline-offset: 2px;
+		}
+
+		// Active (pressed) feedback
+		&:active {
+			transform: scale(0.97);
+		}
+
+		// Disabled state
+		&[aria-disabled="true"] {
+			opacity: 0.6;
+			pointer-events: none;
+		}
+	}
+
+	// Outline button style override
+	&.is-style-outline .wp-block-button__link {
+		background-color: transparent !important;
+		border: var(--btn-border-width) solid var(--default-primary);
+		color: var(--default-primary) !important;
+		width: var(--outline-btn-width);
+		height: var(--outline-btn-height);
+		gap: var(--outline-btn-gap);
+		opacity: 1;
+		// Override theme.json padding for outline buttons
+		padding: var(--spacing-3-5) var(--spacing-6) !important;
+		transition:
+			background-color 0.3s ease,
+			color 0.3s ease,
+			border-color 0.3s ease;
+		will-change: background-color, color, border-color;
+
+		&:hover {
+			background-color: var(--default-primary) !important;
+			color: var(--default-background) !important;
+			border-color: var(--default-primary-accent);
+		}
+
+		&:focus,
+		&:focus-visible {
+			outline: 3px solid var(--default-primary-accent);
+			outline-offset: 2px;
+		}
+
+		&:active {
+			transform: scale(0.97);
+		}
+
+		&[aria-disabled="true"] {
+			opacity: 0.6;
+			pointer-events: none;
+		}
+	}
+}

--- a/assets/css/globals/_buttons.scss
+++ b/assets/css/globals/_buttons.scss
@@ -24,7 +24,7 @@
 		@apply transition-all duration-200 ease-in-out;
 		@apply will-change-[background-color,color,border-color];
 		@apply scale-100;
-		@apply border border-solid border-transparent; /* default transparent border for layout spacing */
+		@apply border border-solid border-transparent;
 
 		&:active {
 			@apply scale-[0.97];

--- a/assets/css/globals/_buttons.scss
+++ b/assets/css/globals/_buttons.scss
@@ -1,154 +1,132 @@
-// Define layer order
-@layer wp-defaults, wp-components, theme-overrides, utilities;
-//@layer global, elements, components, utilities;
-
-// This contains custom properties that are not supported in the theme.json schema
 :root {
+	/* Sizes */
 	--btn-width: 12rem;
 	--btn-height: 56px;
 	--btn-gap: 10px;
-	--outline-btn-width: 12rem;
-	--outline-btn-height: 56px;
-	--outline-btn-gap: 10px;
+
+	/* Borders */
 	--btn-border-width: 2px;
+	--btn-border-highlight: #ffb900;
+
+	/* Colors */
+	--default-primary: #ffb900;
+	--default-primary-accent: #ffd633;
+	--default-background: #ffffff;
+
+	--ghost-hover-bg: #f5f5f5;
 }
 
-@layer theme-overrides {
-	// Fill button styles (default)
-	.wp-block-button {
-		.wp-block-button__link {
-			// theme.json handles: background-color, font-size, line-height, padding, border-radius, color
-			@apply h-auto min-w-(--btn-width) gap-[10px];
-			@apply inline-flex items-center justify-center no-underline;
-			@apply transition-all duration-200 ease-in-out;
-			@apply will-change-[background-color,color,border-color];
+/* Base button */
+.wp-block-button {
+	.wp-block-button__link {
+		@apply h-(--btn-height) min-w-(--btn-width) gap-(--btn-gap);
+		@apply inline-flex items-center justify-center no-underline;
+		@apply transition-all duration-200 ease-in-out;
+		@apply will-change-[background-color,color,border-color];
+		@apply scale-100;
+		@apply border border-solid border-transparent; /* default transparent border for layout spacing */
 
-			// Ensure transitions work everywhere
-			transition:
-				background-color 0.2s ease,
-				color 0.3s ease,
-				border-color 0.2s ease,
-				transform 0.1s ease;
-
-			// Hover state
-			&:hover {
-				background-color: var(--default-primary-accent);
-			}
-
-			// Focus state (keyboard users)
-			&:focus,
-			&:focus-visible {
-				@apply outline-[3px] outline-offset-2 outline-solid;
-				outline-color: #ffb900;
-			}
-
-			// Active (pressed) feedback
-			&:active {
-				@apply scale-[0.97];
-			}
-
-			// Disabled state
-			&[aria-disabled="true"] {
-				@apply pointer-events-none opacity-60;
-			}
+		&:active {
+			@apply scale-[0.97];
 		}
 
-		// Outline button style override
-		&.is-style-outline .wp-block-button__link {
-			@apply border-solid bg-transparent opacity-100;
-			@apply h-(--outline-btn-height) w-(--outline-btn-width) gap-(--outline-btn-gap);
-			@apply transition-all duration-300 ease-in-out;
-			@apply will-change-[background-color,color,border-color];
+		&:focus,
+		&:focus-visible,
+		&.is-active {
+			@apply outline-[3px] outline-offset-2 outline-solid;
+			outline-color: var(--btn-border-highlight);
+		}
 
-			background-color: transparent;
-			border: var(--btn-border-width) solid #ffb900;
-			color: var(--default-primary);
-
-			// Override theme.json padding for outline buttons
-			padding: var(--spacing-3-5) var(--spacing-6);
-			transition:
-				background-color 0.3s ease,
-				color 0.3s ease,
-				border-color 0.3s ease,
-				transform 0.15s ease;
-
-			&:hover {
-				background-color: var(--default-primary);
-				color: var(--default-background);
-				border-color: var(--default-primary-accent);
-			}
-
-			&:focus,
-			&:focus-visible {
-				@apply outline-[3px] outline-offset-2 outline-solid;
-				outline-color: #ffb900;
-			}
-
-			&:active {
-				@apply scale-[0.97];
-			}
-
-			&[aria-disabled="true"] {
-				@apply pointer-events-none opacity-60;
-			}
+		&[aria-disabled="true"] {
+			@apply pointer-events-none opacity-60;
 		}
 	}
 
-	// Editor-specific styles
-	.editor-styles-wrapper .wp-block-button {
-		.wp-block-button__link {
-			// Ensure editor styles match frontend
-			@apply h-auto min-w-(--btn-width) gap-[10px];
-			@apply transition-all duration-300 ease-in-out;
+	/* Fill button */
+	&.is-style-fill .wp-block-button__link {
+		@apply bg-(--default-primary) text-(--default-background);
 
-			&:hover {
-				background-color: var(--default-primary-accent);
-			}
-
-			&:active {
-				@apply scale-[0.97];
-			}
-		}
-
-		&.is-style-outline .wp-block-button__link {
-			@apply bg-transparent;
-			background-color: transparent;
-			border: var(--btn-border-width) solid var(--default-primary);
-			color: var(--default-primary);
-
-			&:hover {
-				background-color: var(--default-primary);
-				color: var(--default-background);
-			}
+		&:hover {
+			background-color: var(--default-primary-accent);
 		}
 	}
 
-	// Block editor specific styles
-	.block-editor-block-list__layout .wp-block-button {
-		.wp-block-button__link {
-			@apply transition-all duration-300 ease-in-out;
+	/* Outline button */
+	&.is-style-outline .wp-block-button__link {
+		@apply bg-transparent text-(--default-primary);
+		border-width: var(--btn-border-width);
+		border-color: var(--default-primary);
 
-			&:hover {
-				background-color: var(--default-primary-accent);
-			}
+		&:hover {
+			border-color: var(--default-primary-accent);
+			background-color: var(--default-primary);
+			color: var(--default-background);
+		}
+	}
+
+	/* Ghost button */
+	&.is-style-ghost .wp-block-button__link {
+		@apply bg-transparent;
+		border-width: var(--btn-border-width);
+		border-color: transparent;
+
+		&:hover {
+			background-color: var(--ghost-hover-bg);
+			border-color: transparent;
 		}
 	}
 }
 
-@layer utilities {
-	.btn-no-animation {
-		@apply transition-none;
-		transform: none !important;
-	}
+/* Dark mode / prefers-color-scheme */
+@media (prefers-color-scheme: dark) {
+	.wp-block-button.is-style-ghost .wp-block-button__link {
+		color: var(--default-primary);
 
-	.btn-full-width {
-		@apply w-full;
-		width: 100%;
+		&:hover {
+			color: var(--default-background);
+		}
 	}
 }
 
-// Accessibility: High-contrast support (Windows forced-colors)
-// This stays outside layers as it's a media query override
+/* Editor-specific styles */
+.editor-styles-wrapper .wp-block-button {
+	.wp-block-button__link {
+		@apply h-(--btn-height) min-w-(--btn-width) gap-(--btn-gap);
+		@apply transition-all duration-300 ease-in-out;
+
+		&:hover {
+			background-color: var(--default-primary-accent);
+		}
+
+		&:active {
+			@apply scale-[0.97];
+		}
+	}
+}
+
+/* Block editor */
+.block-editor-block-list__layout .wp-block-button {
+	.wp-block-button__link {
+		@apply transition-all duration-300 ease-in-out;
+
+		&:hover {
+			background-color: var(--default-primary-accent);
+		}
+	}
+}
+
+/* Utilities */
+.btn-no-animation {
+	@apply transition-none;
+	transform: none !important;
+}
+
+.btn-full-width {
+	@apply w-full;
+	width: 100%;
+}
+
+/* High-contrast (Windows forced-colors) */
 @media (forced-colors: active) {
 	.wp-block-button__link,
 	.wp-block-button.is-style-outline .wp-block-button__link {
@@ -159,7 +137,7 @@
 	}
 }
 
-// Print styles
+/* Print */
 @media print {
 	.wp-block-button__link {
 		@apply border border-solid border-black bg-transparent text-black;
@@ -172,52 +150,14 @@
 	}
 }
 
-// Reduced motion support
+/* Reduced motion */
 @media (prefers-reduced-motion: reduce) {
 	.wp-block-button__link {
 		@apply transition-none;
 		transition: none;
 
 		&:active {
-			@apply scale-100; // No scale animation for reduced motion
-		}
-	}
-}
-
-// Fallback for browsers that don't support @layer
-@supports not (selector(layer())) {
-	// High specificity fallback styles
-	.wp-site-blocks .wp-block-button .wp-block-button__link,
-	.editor-styles-wrapper .wp-block-button .wp-block-button__link {
-		min-width: var(--btn-width);
-		height: var(--btn-height);
-		gap: 10px;
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		text-decoration: none;
-		transition: all 0.3s ease;
-
-		&:hover {
-			background-color: var(--default-primary-accent);
-		}
-
-		&:active {
-			transform: scale(0.97);
-		}
-	}
-
-	.wp-site-blocks .wp-block-button.is-style-outline .wp-block-button__link,
-	.editor-styles-wrapper
-		.wp-block-button.is-style-outline
-		.wp-block-button__link {
-		background-color: transparent;
-		border: var(--btn-border-width) solid var(--default-primary);
-		color: var(--default-primary);
-
-		&:hover {
-			background-color: var(--default-primary);
-			color: var(--default-background);
+			@apply scale-100;
 		}
 	}
 }

--- a/assets/css/globals/_buttons.scss
+++ b/assets/css/globals/_buttons.scss
@@ -5,10 +5,10 @@
 // This contains custom properties that are not supported in the theme.json schema
 :root {
 	--btn-width: 12rem;
-	--btn-height: auto;
+	--btn-height: 56px;
 	--btn-gap: 10px;
 	--outline-btn-width: 12rem;
-	--outline-btn-height: auto;
+	--outline-btn-height: 56px;
 	--outline-btn-gap: 10px;
 	--btn-border-width: 2px;
 }
@@ -190,7 +190,7 @@
 	.wp-site-blocks .wp-block-button .wp-block-button__link,
 	.editor-styles-wrapper .wp-block-button .wp-block-button__link {
 		min-width: var(--btn-width);
-		height: auto;
+		height: var(--btn-height);
 		gap: 10px;
 		display: inline-flex;
 		align-items: center;

--- a/assets/css/globals/_buttons.scss
+++ b/assets/css/globals/_buttons.scss
@@ -94,3 +94,13 @@
 		}
 	}
 }
+
+// Accessibility: High-contrast support (Windows forced-colors)
+@media (forced-colors: active) {
+	.wp-block-button__link,
+	.wp-block-button.is-style-outline .wp-block-button__link {
+		border: 1px solid ButtonText;
+		color: ButtonText !important;
+		background: ButtonFace !important;
+	}
+}

--- a/assets/css/globals/_buttons.scss
+++ b/assets/css/globals/_buttons.scss
@@ -92,8 +92,10 @@
 /* Editor-specific styles */
 .editor-styles-wrapper .wp-block-button {
 	.wp-block-button__link {
-		@apply h-(--btn-height) min-w-(--btn-width) gap-(--btn-gap);
 		@apply transition-all duration-300 ease-in-out;
+		height: var(--btn-height);
+		min-width: var(--btn-width);
+		gap: var(--btn-gap);
 
 		&:hover {
 			background-color: var(--default-primary-accent);
@@ -103,15 +105,31 @@
 			@apply scale-[0.97];
 		}
 	}
+
+	/* Ghost style override */
+	&.is-style-ghost .wp-block-button__link {
+		&:hover {
+			background-color: var(--ghost-hover-bg);
+			border-color: transparent;
+		}
+	}
 }
 
-/* Block editor */
+/* Block editor preview */
 .block-editor-block-list__layout .wp-block-button {
 	.wp-block-button__link {
 		@apply transition-all duration-300 ease-in-out;
 
 		&:hover {
 			background-color: var(--default-primary-accent);
+		}
+	}
+
+	/* Ghost style override */
+	&.is-style-ghost .wp-block-button__link {
+		&:hover {
+			background-color: var(--ghost-hover-bg);
+			border-color: transparent;
 		}
 	}
 }

--- a/assets/css/globals/_buttons.scss
+++ b/assets/css/globals/_buttons.scss
@@ -7,9 +7,9 @@
 	--btn-width: 12rem;
 	--btn-height: auto;
 	--btn-gap: 10px;
-	--outline-btn-width: 208px;
-	--outline-btn-height: 56px;
-	--outline-btn-gap: 16px;
+	--outline-btn-width: 12rem;
+	--outline-btn-height: auto;
+	--outline-btn-gap: 10px;
 	--btn-border-width: 2px;
 }
 

--- a/assets/css/globals/_index.scss
+++ b/assets/css/globals/_index.scss
@@ -1,5 +1,6 @@
 // Forward all theme modules
 @forward "base";
+@forward "buttons";
 @forward "colors";
 @forward "typography";
 @forward "spacing";

--- a/functions.php
+++ b/functions.php
@@ -119,7 +119,7 @@ add_filter('body_class', 'gw_add_body_class');
 require get_template_directory() . '/inc/acf/acf.php';
 
 /**
- * Register additional custom button styles for Govwind theme
+ * Register additional core/button block styles
  */
 function govwind_register_button_styles()
 {

--- a/functions.php
+++ b/functions.php
@@ -117,3 +117,18 @@ add_filter('body_class', 'gw_add_body_class');
  * ACF
  */
 require get_template_directory() . '/inc/acf/acf.php';
+
+/**
+ * Register additional custom button styles for Govwind theme
+ */
+function govwind_register_button_styles()
+{
+    register_block_style(
+        'core/button',
+        array(
+            'name'  => 'ghost',
+            'label' => __('Ghost', 'govwind'),
+        )
+    );
+}
+add_action('init', 'govwind_register_button_styles');

--- a/theme.json
+++ b/theme.json
@@ -223,18 +223,19 @@
 					"text": "var(--default-background)"
 				},
 				"border": {
-					"radius": "var(--radius-md)"
+					"radius": "var(--radius-sm)"
 				},
 				"spacing": {
 					"padding": {
-						"top": "var(--spacing-2)",
-						"bottom": "var(--spacing-2)",
+						"top": "var(--spacing-2-5)",
+						"bottom": "var(--spacing-2-5)",
 						"left": "var(--spacing-4)",
 						"right": "var(--spacing-4)"
 					}
 				},
 				"typography": {
-					"fontSize": "var(--font-size-sm)"
+					"fontSize": "var(--font-size-lg)",
+					"lineHeight": "1.75"
 				},
 				":hover": {
 					"color": {
@@ -310,6 +311,32 @@
 				"typography": {
 					"fontFamily": "var(--font-family-mono)",
 					"fontSize": "var(--font-size-sm)"
+				}
+			},
+			"core/button": {
+				"color": {
+					"background": "var(--default-primary)",
+					"text": "var(--default-background)"
+				},
+				"border": {
+					"radius": "var(--radius-md)"
+				},
+				"spacing": {
+					"padding": {
+						"top": "var(--spacing-2-5)",
+						"bottom": "var(--spacing-2-5)",
+						"left": "var(--spacing-4)",
+						"right": "var(--spacing-4)"
+					}
+				},
+				"typography": {
+					"fontSize": "var(--font-size-lg)",
+					"lineHeight": "1.75"
+				},
+				":hover": {
+					"color": {
+						"background": "var(--default-primary-accent)"
+					}
 				}
 			}
 		}


### PR DESCRIPTION
These styles are applied over the core/button styles using the
theme.json when possible and falling back to SASS for more complex
behaviours that are not possible via the json schema.

This does not include the button icon work. That will be part of a separate dedeciated PR.