### PR TITLE
Heading font sizes 4751

### DIFF
--- a/assets/css/globals/_typography.scss
+++ b/assets/css/globals/_typography.scss
@@ -5,7 +5,7 @@
 	--font-size-base: clamp(1rem, 3vw, 1.1875rem);
 	--font-size-lg: clamp(1rem, 3.5vw, 1.25rem);
 	--font-size-xl: clamp(1.125rem, 4vw, 1.5rem);
-	--font-size-2-xl: clamp(1.25rem, 4.5vw, 1.5rem);
+	--font-size-2-xl: clamp(1.25rem, 4.5vw, 1.75rem);
 	--font-size-3-xl: clamp(1.5rem, 5vw, 1.875rem);
 	--font-size-4-xl: clamp(1.875rem, 6vw, 2.25rem);
 	--font-size-5-xl: clamp(2.25rem, 7vw, 3rem);

--- a/patterns/feature-two-col.php
+++ b/patterns/feature-two-col.php
@@ -16,8 +16,8 @@
 		<div class="wp-block-columns alignwide">
 			<!-- wp:column {"width":"60%","verticalAlignment":"top","style":{"spacing":{"padding":{"right":"var:preset|spacing|50"}}}} -->
 			<div class="wp-block-column is-vertically-aligned-top" style="flex-basis:60%;padding-right:var(--wp--preset--spacing--50)">
-				<!-- wp:heading {"textAlign":"left","level":4} -->
-				<h4 class="wp-block-heading has-text-align-left">Feature pattern title</h4>
+				<!-- wp:heading {"textAlign":"left","level":2} -->
+				<h2 class="wp-block-heading has-text-align-left">Feature pattern title</h2>
 				<!-- /wp:heading -->
 				<!-- wp:paragraph -->
 				<p>Add your feature paragraph text in this section.</p>

--- a/patterns/feature-two-col.php
+++ b/patterns/feature-two-col.php
@@ -16,8 +16,8 @@
 		<div class="wp-block-columns alignwide">
 			<!-- wp:column {"width":"60%","verticalAlignment":"top","style":{"spacing":{"padding":{"right":"var:preset|spacing|50"}}}} -->
 			<div class="wp-block-column is-vertically-aligned-top" style="flex-basis:60%;padding-right:var(--wp--preset--spacing--50)">
-				<!-- wp:heading {"textAlign":"left","level":2} -->
-				<h2 class="wp-block-heading has-text-align-left">Feature pattern title</h2>
+				<!-- wp:heading {"textAlign":"left","level":2,"fontSize":"3-xl"} -->
+				<h2 class="wp-block-heading has-text-align-left has-3-xl-font-size">Feature pattern title</h2>
 				<!-- /wp:heading -->
 				<!-- wp:paragraph -->
 				<p>Add your feature paragraph text in this section.</p>

--- a/patterns/icon-grid-cta.php
+++ b/patterns/icon-grid-cta.php
@@ -17,8 +17,8 @@
 
 		<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 		<div class="wp-block-group">
-			<!-- wp:heading {"align":"wide","level":4} -->
-			<h4 class="wp-block-heading alignwide">Add your heading</h4>
+			<!-- wp:heading {"align":"wide","level":2} -->
+			<h2 class="wp-block-heading alignwide">Add your heading</h2>
 			<!-- /wp:heading -->
 		</div>
 		<!-- /wp:group -->

--- a/patterns/icon-grid-cta.php
+++ b/patterns/icon-grid-cta.php
@@ -17,8 +17,8 @@
 
 		<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 		<div class="wp-block-group">
-			<!-- wp:heading {"align":"wide","level":2} -->
-			<h2 class="wp-block-heading alignwide">Add your heading</h2>
+			<!-- wp:heading {"align":"wide","level":2,"fontSize":"3-xl"} -->
+			<h2 class="wp-block-heading alignwide has-3-xl-font-size">Add your heading</h2>
 			<!-- /wp:heading -->
 		</div>
 		<!-- /wp:group -->

--- a/patterns/icon-info-card.php
+++ b/patterns/icon-info-card.php
@@ -22,8 +22,8 @@
     ); ?>" alt="" style="object-fit:contain;width:48px;height:48px" /></figure>
     <!-- /wp:image -->
 
-    <!-- wp:heading {"level":3,"style":{"spacing":{"margin":{"top":"0"}}},"fontSize":"base"} -->
-    <h3 class="wp-block-heading has-base-font-size" style="margin-top:0">Add your heading here.</h3>
+    <!-- wp:heading {"level":2,"style":{"spacing":{"margin":{"top":"0"}}},"fontSize":"base"} -->
+    <h2 class="wp-block-heading has-base-font-size" style="margin-top:0">Add your heading here.</h2>
     <!-- /wp:heading -->
 
     <!-- wp:paragraph -->

--- a/patterns/icon-info-card.php
+++ b/patterns/icon-info-card.php
@@ -22,8 +22,8 @@
     ); ?>" alt="" style="object-fit:contain;width:48px;height:48px" /></figure>
     <!-- /wp:image -->
 
-    <!-- wp:heading {"level":2,"style":{"spacing":{"margin":{"top":"0"}}},"fontSize":"base"} -->
-    <h2 class="wp-block-heading has-base-font-size" style="margin-top:0">Add your heading here.</h2>
+    <!-- wp:heading {"level":2,"style":{"spacing":{"margin":{"top":"0"}}},"fontSize":"3-xl"} -->
+    <h2 class="wp-block-heading has-3-xl-font-size" style="margin-top:0">Add your heading here.</h2>
     <!-- /wp:heading -->
 
     <!-- wp:paragraph -->

--- a/patterns/icon-info-cards-three-col.php
+++ b/patterns/icon-info-cards-three-col.php
@@ -26,8 +26,8 @@
             </figure>
             <!-- /wp:image -->
 
-            <!-- wp:heading {"level":3,"style":{"spacing":{"margin":{"top":"0"}}},"fontSize":"base"} -->
-            <h3 class="wp-block-heading has-base-font-size" style="margin-top:0">Add your heading here.</h3>
+            <!-- wp:heading {"level":2,"style":{"spacing":{"margin":{"top":"0"}}},"fontSize":"base"} -->
+            <h2 class="wp-block-heading has-base-font-size" style="margin-top:0">Add your heading here.</h2>
             <!-- /wp:heading -->
 
             <!-- wp:paragraph -->
@@ -49,8 +49,8 @@
             </figure>
             <!-- /wp:image -->
 
-            <!-- wp:heading {"level":3,"style":{"spacing":{"margin":{"top":"0"}}},"fontSize":"base"} -->
-            <h3 class="wp-block-heading has-base-font-size" style="margin-top:0">Add your heading here.</h3>
+            <!-- wp:heading {"level":2,"style":{"spacing":{"margin":{"top":"0"}}},"fontSize":"base"} -->
+            <h2 class="wp-block-heading has-base-font-size" style="margin-top:0">Add your heading here.</h2>
             <!-- /wp:heading -->
 
             <!-- wp:paragraph -->
@@ -72,8 +72,8 @@
             </figure>
             <!-- /wp:image -->
 
-            <!-- wp:heading {"level":3,"style":{"spacing":{"margin":{"top":"0"}}},"fontSize":"base"} -->
-            <h3 class="wp-block-heading has-base-font-size" style="margin-top:0">Add your heading here.</h3>
+            <!-- wp:heading {"level":2,"style":{"spacing":{"margin":{"top":"0"}}},"fontSize":"base"} -->
+            <h2 class="wp-block-heading has-base-font-size" style="margin-top:0">Add your heading here.</h2>
             <!-- /wp:heading -->
 
             <!-- wp:paragraph -->

--- a/patterns/icon-info-cards-three-col.php
+++ b/patterns/icon-info-cards-three-col.php
@@ -26,8 +26,8 @@
             </figure>
             <!-- /wp:image -->
 
-            <!-- wp:heading {"level":2,"style":{"spacing":{"margin":{"top":"0"}}},"fontSize":"base"} -->
-            <h2 class="wp-block-heading has-base-font-size" style="margin-top:0">Add your heading here.</h2>
+            <!-- wp:heading {"level":2,"style":{"spacing":{"margin":{"top":"0"}}},"fontSize":"3-xl"} -->
+            <h2 class="wp-block-heading has-3-xl-font-size" style="margin-top:0">Add your heading here.</h2>
             <!-- /wp:heading -->
 
             <!-- wp:paragraph -->
@@ -49,8 +49,8 @@
             </figure>
             <!-- /wp:image -->
 
-            <!-- wp:heading {"level":2,"style":{"spacing":{"margin":{"top":"0"}}},"fontSize":"base"} -->
-            <h2 class="wp-block-heading has-base-font-size" style="margin-top:0">Add your heading here.</h2>
+            <!-- wp:heading {"level":2,"style":{"spacing":{"margin":{"top":"0"}}},"fontSize":"3-xl"} -->
+            <h2 class="wp-block-heading has-3-xl-font-size" style="margin-top:0">Add your heading here.</h2>
             <!-- /wp:heading -->
 
             <!-- wp:paragraph -->
@@ -72,8 +72,8 @@
             </figure>
             <!-- /wp:image -->
 
-            <!-- wp:heading {"level":2,"style":{"spacing":{"margin":{"top":"0"}}},"fontSize":"base"} -->
-            <h2 class="wp-block-heading has-base-font-size" style="margin-top:0">Add your heading here.</h2>
+            <!-- wp:heading {"level":2,"style":{"spacing":{"margin":{"top":"0"}}},"fontSize":"3-xl"} -->
+            <h2 class="wp-block-heading has-3-xl-font-size" style="margin-top:0">Add your heading here.</h2>
             <!-- /wp:heading -->
 
             <!-- wp:paragraph -->


### PR DESCRIPTION
  fix(patterns): set content pattern headings to h2 with 3-xl font size

  Heading levels were h3/h4 — updated to h2 for correct document
  outline. Font size standardised to 3-xl across all affected patterns.

  Patterns changed: feature-two-col, icon-grid-cta, icon-info-card,
  icon-info-cards-three-col

 Also fix 2xl size discrepancy 