### PR TITLE
Added printing styles & dark/light mode override class

### DIFF
--- a/assets/css/globals/_accessibility.scss
+++ b/assets/css/globals/_accessibility.scss
@@ -1,5 +1,5 @@
 // Dark mode support
-@media (prefers-color-scheme: dark) {
+@media screen and (prefers-color-scheme: dark) {
 	// Only apply if theme supports dark mode
 	:root[data-theme="auto"],
 	:root:not([data-theme]) {

--- a/assets/css/globals/_header&footer.scss
+++ b/assets/css/globals/_header&footer.scss
@@ -91,8 +91,6 @@ header {
 	* (colours and hover colours are dealt with in WordPress, hover states are the same as elsewhere)
 */
 footer {
-	background-color: var(--colour-header-background);
-	color: var(--colour-header-foreground);
 	a,
 	.wp-block-navigation a {
 		text-decoration: underline;
@@ -105,5 +103,6 @@ footer {
 	.wp-element-button {
 		color: var(--colour-header-background);
 		background-color: var(--colour-header-foreground);
+		border: 1px solid var(--colour-header-foreground);
 	}
 }

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -9,7 +9,7 @@
 //override base styles but can be overridden by component styles.
 // TODO: test this further
 
-@layer base, components, utilities, importants;
+@layer base, utilities, components, importants;
 
 @layer utilities {
 	.wp-block-gap {

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1,6 +1,7 @@
 // Import all theme tokens using modern Sass (must be first)
 @use "./globals" as *;
 @use "./style-variations" as *;
+@use "./printing" as *;
 
 // Custom utilities and components
 //This is a CSS Cascade Layers feature that ensures these utilities have the
@@ -8,7 +9,7 @@
 //override base styles but can be overridden by component styles.
 // TODO: test this further
 
-@layer utilities, importants;
+@layer base, components, utilities, importants;
 
 @layer utilities {
 	.wp-block-gap {

--- a/assets/css/printing/_colours.scss
+++ b/assets/css/printing/_colours.scss
@@ -1,0 +1,140 @@
+/**
+ * Printing colour changes
+ * This file amends the colours to be printer-friendly.
+ *
+ * Text is always true black, backgrounds are all true white.
+ * Header is black text on white with a line of the header colour beneath it.
+ * Footer is black on white, with black border given to buttons.
+ * Buttons have their background used for their border and are black on white.
+ * Other colours will always be light mode (dark mode only for @media screen).
+ *
+ * Blocks with a custom background have that background colour moved to a border.
+ * They will have black text on white.
+ *
+ **/
+
+@mixin wb-printable-background($colour) {
+	// Apply the old background colour to be a thick border
+	border: 10px solid $colour;
+	// Change the background to white and the text to black
+	background-color: #fff !important;
+	color: #000 !important;
+	* {
+		// Colour of all child elements needs to be black too
+		color: #000 !important;
+	}
+	// Change the link to the light mode link colour
+	a {
+		color: var(--link-text--light-mode) !important;
+	}
+	// Narrower border for buttons
+	&:is(.wp-element-button),
+	&:is(.wp-block-button__link) {
+		border-width: 6px;
+	}
+}
+
+@media print {
+	:root {
+		//colours - if undeclared, light mode shall be used
+		--colour-page-background: #fff;
+		--colour-foreground: #000;
+
+		--colour-header-background: #fff;
+		--colour-header-foreground: #000;
+		header {
+			// Uses the header colour as a bottom border
+			padding-bottom: 0.5rem;
+			border-bottom: 8px solid var(--header-background--light-mode);
+			margin-bottom: 0.5rem;
+		}
+		// No visited link colour
+		--colour-link-text-visited: var(--link-text--light-mode) !important;
+
+		// Buttons: move background colour to border
+		:where(main .wp-element-button, main .wp-block-button__link) {
+			border: 6px solid var(--button-background--light-mode);
+			color: #000;
+			background-color: #fff;
+		}
+
+		footer,
+		footer * {
+			color: #000 !important;
+			background-color: #fff !important;
+
+			button,
+			.wp-block-button a {
+				border: 1px solid #000; //force a border for buttons
+			}
+		}
+		footer {
+			margin-top: 0.5rem;
+			border-color: #000;
+			border-top-style: solid;
+		}
+
+		main .has-background:not(hr) {
+			// If a block has a custom background, we change it to a border and make the background white
+			// Browsers sometimes remove the background on print anyway, so we need to ensure the text is readable.
+			// Even lighter colours need to be done to ensure the page is consistent and to save ink.
+
+			// Fallback in case colour not known
+			@include wb-printable-background(#999);
+
+			&.has-colour-z-background-color {
+				@include wb-printable-background(var(--wp--preset--color--colour-z));
+			}
+			&.has-colour-y-background-color {
+				@include wb-printable-background(var(--wp--preset--color--colour-y));
+			}
+			// Darker (YZ) greyscale colours
+			&.has-greyscale-y-background-color {
+				@include wb-printable-background(var(--wp--preset--color--greyscale-y));
+			}
+			&.has-greyscale-z-background-color {
+				@include wb-printable-background(var(--wp--preset--color--greyscale-z));
+			}
+
+			// Lighter (AB) greyscale colours
+			&.has-greyscale-a-background-color {
+				@include wb-printable-background(var(--wp--preset--color--greyscale-a));
+			}
+			&.has-greyscale-b-background-color {
+				@include wb-printable-background(var(--wp--preset--color--greyscale-b));
+			}
+
+			// Site-specific colours which aren't in the default (we don't know whether they are dark or light)
+			&.has-site-colour-palette-1-background-color {
+				@include wb-printable-background(
+					var(--wp--preset--color--site-colour-palette-1)
+				);
+			}
+			&.has-site-colour-palette-2-background-color {
+				@include wb-printable-background(
+					var(--wp--preset--color--site-colour-palette-2)
+				);
+			}
+			&.has-site-colour-palette-3-background-color {
+				@include wb-printable-background(
+					var(--wp--preset--color--site-colour-palette-3)
+				);
+			}
+			&.has-site-colour-palette-4-background-color {
+				@include wb-printable-background(
+					var(--wp--preset--color--site-colour-palette-4)
+				);
+			}
+			&.has-site-colour-palette-5-background-color {
+				@include wb-printable-background(
+					var(--wp--preset--color--site-colour-palette-5)
+				);
+			}
+			&.has-site-colour-palette-6-background-color {
+				@include wb-printable-background(
+					var(--wp--preset--color--site-colour-palette-6)
+				);
+			}
+		}
+	}
+}

--- a/assets/css/printing/_index.scss
+++ b/assets/css/printing/_index.scss
@@ -1,0 +1,3 @@
+// Forward all theme modules
+@forward "layout";
+@forward "colours";

--- a/assets/css/printing/_layout.scss
+++ b/assets/css/printing/_layout.scss
@@ -12,7 +12,7 @@
 
 @media print {
 	// Hiding elements of the header which are interactive
-	// All navs, all groups except those contaning the logo/site name
+	// All navs, all groups except those containing the logo/site name
 	header {
 		*.wp-block-group:not(:has(.wp-block-site-title)):not(
 				:has(.wp-block-site-logo)
@@ -30,7 +30,11 @@
 		display: none;
 	}
 	// Link suffix
-	a[href^="http"]:not(header a):not(a[href=""])::after {
+	a[target="_blank"]:after {
+		content:""; //removes "open in a new tab"
+	}
+	a[href^="/"]:not(header a):not(a[href=""]):after,
+	a[href^="http"]:not(header a):not(a[href=""]):after {
 		content: " (" attr(href) ")";
 		font-size: 0.8rem;
 	}

--- a/assets/css/printing/_layout.scss
+++ b/assets/css/printing/_layout.scss
@@ -1,0 +1,42 @@
+/**
+ * Printing layout changes
+ * This file amends the non-colour styles to be printer-friendly.
+ *
+ * Removes the navigation from the header.
+ * Removes groups which do not have the logo or site title in them.
+ *
+ * Adds a suffix to links with the URL.  This replaces any "opens in a new tab" suffix.
+ * For buttons, the suffix is on a new line.
+ *
+ **/
+
+@media print {
+	// Hiding elements of the header which are interactive
+	// All navs, all groups except those contaning the logo/site name
+	header {
+		*.wp-block-group:not(:has(.wp-block-site-title)):not(
+				:has(.wp-block-site-logo)
+			),
+		.wp-block-navigation {
+			display: none;
+		}
+	}
+	// Hiding Breadcrumb block
+	.wp-block-boldblocks-breadcrumb-block {
+		display: none;
+	}
+	// Hiding table of contents jump to top links
+	.wb-jump-link {
+		display: none;
+	}
+	// Link suffix
+	a[href^="http"]:not(header a):not(a[href=""])::after {
+		content: " (" attr(href) ")";
+		font-size: 0.8rem;
+	}
+	:where(main .wp-element-button, main .wp-block-button__link) {
+		&::after {
+			display: block;
+		}
+	}
+}

--- a/assets/css/printing/_layout.scss
+++ b/assets/css/printing/_layout.scss
@@ -31,7 +31,7 @@
 	}
 	// Link suffix
 	a[target="_blank"]:after {
-		content:""; //removes "open in a new tab"
+		content: ""; //removes "open in a new tab"
 	}
 	a[href^="/"]:not(header a):not(a[href=""]):after,
 	a[href^="http"]:not(header a):not(a[href=""]):after {

--- a/assets/css/style-variations/_dark-mode.scss
+++ b/assets/css/style-variations/_dark-mode.scss
@@ -1,5 +1,5 @@
 @mixin force-dark {
-	.force-dark {
+	.wb-force-dark {
 		&,
 		* {
 			&:not(:focus):not(:focus *) {

--- a/assets/css/style-variations/_dark-mode.scss
+++ b/assets/css/style-variations/_dark-mode.scss
@@ -1,38 +1,49 @@
+@mixin force-dark {
+	.force-dark {
+		&,
+		* {
+			&:not(:focus):not(:focus *) {
+				color: var(--forced-light-colour) !important;
+				border-color: var(--forced-light-colour) !important;
+				background-color: var(--forced-dark-colour) !important;
+			}
+		}
+		&.has-background,
+		*.has-background {
+			&:not(:focus):not(:focus *) {
+				background-color: var(--forced-dark-colour) !important;
+			}
+		}
+		&.has-text-color,
+		*.has-text-color {
+			&:not(:focus):not(:focus *) {
+				color: var(--forced-light-colour) !important;
+			}
+		}
+		:where(.wp-element-button, .wp-block-button__link) {
+			// buttons will need a border as their background will be forced to be the same as the page background.
+			&:not([style*="border-width"]),
+			&:is([style*="border-width:0"]) {
+				border-style: solid !important;
+				border-width: 2px !important;
+			}
+		}
+	}
+}
+
 @layer importants {
-	@media (prefers-color-scheme: dark) {
+	@media screen and (prefers-color-scheme: dark) {
 		// Forcing dark mode colours where the switch doesn't work, all colours are forced
 		// to dark background, light foreground (inc borders).
 		// Focussed elements exempt.
 
-		.force-dark {
-			&,
-			* {
-				&:not(:focus):not(:focus *) {
-					color: var(--forced-light-colour) !important;
-					border-color: var(--forced-light-colour) !important;
-					background-color: var(--forced-dark-colour) !important;
-				}
-			}
-			&.has-background,
-			*.has-background {
-				&:not(:focus):not(:focus *) {
-					background-color: var(--forced-dark-colour) !important;
-				}
-			}
-			&.has-text-color,
-			*.has-text-color {
-				&:not(:focus):not(:focus *) {
-					color: var(--forced-light-colour) !important;
-				}
-			}
-			:where(.wp-element-button, .wp-block-button__link) {
-				// buttons will need a border as their background will be forced to be the same as the page background.
-				&:not([style*="border-width"]),
-				&:is([style*="border-width:0"]) {
-					border-style: solid !important;
-					border-width: 2px !important;
-				}
-			}
+		:root:not(.light-mode) {
+			@include force-dark;
+		}
+	}
+	@media screen {
+		:root.dark-mode {
+			@include force-dark;
 		}
 	}
 }

--- a/assets/css/style-variations/_index.scss
+++ b/assets/css/style-variations/_index.scss
@@ -57,8 +57,16 @@ $colour-list: list.join($palette-colour-list, $other-colour-list);
 :root {
 	@include wb-summon-palette($colours: $colour-list, $mode: light-mode);
 
-	@media (prefers-color-scheme: dark) {
-		@include wb-summon-palette($colours: $colour-list, $mode: dark-mode);
+	&:not(.light-mode) {
+		@media screen and (prefers-color-scheme: dark) {
+			@include wb-summon-palette($colours: $colour-list, $mode: dark-mode);
+		}
+	}
+
+	&.dark-mode {
+		@media screen {
+			@include wb-summon-palette($colours: $colour-list, $mode: dark-mode);
+		}
 	}
 }
 


### PR DESCRIPTION
Printing styles:

- Made dark mode dependent on `@media screen` so printing is never dark mode and uses light mode colours.
- Overrode the background & foreground colours to be true white and black: #fff & #000.
- Removed the coloured background from headers and footers, and other blocks, so they are printer friendly.
  - Headers have an underline with the light mode header background colour - to keep some branding.
  - Footers are forced to black on white
  - Other blocks with a custom background have that moved to a border and is white text on black.  
  - Buttons are as above but have a thinner border.
- Links have the URL as a suffix - and no longer have "opens in a new tab".  
  - Buttons have the URL on a new line.
- Header has non-branding elements hidden.
  - Group blocks which don't contain the site title or site logo are hidden.
  - Navigation blocks are hidden.
- Hid breadcrumbs & ToC jump to top links

Dark mode/Light mode:
- Dark mode only on `@media screen`.
- Added styles to override browser setting, so a class of `dark-mode` or `light-mode` on the `<html>` will enable said mode regardless of browser settings - for potential future toggle.  