### PR TITLE
Gutter fix

### DIFF
--- a/assets/css/globals/_breakpoint-visibility.scss
+++ b/assets/css/globals/_breakpoint-visibility.scss
@@ -1,15 +1,9 @@
 /*
 Shewing and hiding things at different breakpoints.
 Shewing warnings in the backend that things might be hidden or shewn at different widths.
-
-Sizes used in _layout.scss
-Mobile nav starts at 600px - no variable as far as I can see - hard coded
 */
-$size-sm: 640px;
-$size-md: 768px;
-$size-lg: 1024px;
-$size-xl: 1280px;
-$size-xxl: 1536px;
+
+@use "variables" as *;
 
 @mixin editor-visibility($class, $colour, $text) {
 	//styles for editor screens, so hidden elements aren't missed whilst editing

--- a/assets/css/globals/_layout.scss
+++ b/assets/css/globals/_layout.scss
@@ -59,4 +59,22 @@
 	--timing-in: cubic-bezier(0.4, 0, 1, 1);
 	--timing-out: cubic-bezier(0, 0, 0.2, 1);
 	--timing-in-out: cubic-bezier(0.4, 0, 0.2, 1);
+
+	--gutter-size: 16px;
+	@media (width >= 768px) {
+		--gutter-size: 32px;
+	}
+	@media (width >= 1088px) {
+		//1088px = 1024px + 2*32px
+		--gutter-size: clamp(
+			32px,
+			-58.4px + 8.3333vw,
+			60px
+		); //gradual increase from 32 to 60px
+	}
+
+	body {
+		--wp--style--root--padding-right: var(--gutter-size);
+		--wp--style--root--padding-left: var(--gutter-size);
+	}
 }

--- a/assets/css/globals/_layout.scss
+++ b/assets/css/globals/_layout.scss
@@ -64,13 +64,9 @@
 	@media (width >= 768px) {
 		--gutter-size: 32px;
 	}
-	@media (width >= 1088px) {
-		//1088px = 1024px + 2*32px
-		--gutter-size: clamp(
-			32px,
-			-58.4px + 8.3333vw,
-			60px
-		); //gradual increase from 32 to 60px
+	@media (width >= 1024px) {
+		//gradual increase from 32 to 128px, it'll reach 128px at a screen width 1536px
+		--gutter-size: clamp(32px, 18.75vw - 160px, 128px);
 	}
 
 	body {

--- a/assets/css/globals/_layout.scss
+++ b/assets/css/globals/_layout.scss
@@ -1,3 +1,5 @@
+@use "variables" as *;
+
 :root {
 	/*
 		Layout Constraints
@@ -5,13 +7,13 @@
 
 	*/
 
-	--size-content: $size-xl;
-	--size-wide: $size-xxl;
-	--size-screen-sm: $size-sm;
-	--size-screen-md: $size-md;
-	--size-screen-lg: $size-lg;
-	--size-screen-xl: $size-xl;
-	--size-screen-2xl: $size-xxl;
+	--size-content: #{$size-xl};
+	--size-wide: #{$size-xxl};
+	--size-screen-sm: #{$size-sm};
+	--size-screen-md: #{$size-md};
+	--size-screen-lg: #{$size-lg};
+	--size-screen-xl: #{$size-xl};
+	--size-screen-2xl: #{$size-xxl};
 
 	/* Readable text */
 	--max-prose-width: 789px;
@@ -61,12 +63,12 @@
 	--timing-in-out: cubic-bezier(0.4, 0, 0.2, 1);
 
 	--gutter-size: 16px;
-	@media (width >= 768px) {
+	@media (width >= $size-md) {
 		--gutter-size: 32px;
 	}
-	@media (width >= 1024px) {
+	@media (width >= $size-lg) {
 		//gradual increase from 32 to 128px, it'll reach 128px at a screen width 1536px
-		--gutter-size: clamp(32px, 18.75vw - 160px, 128px);
+		@include fluid(--gutter-size, 32px, 128px, $size-lg, $size-xxl);
 	}
 
 	body {

--- a/assets/css/globals/_typography.scss
+++ b/assets/css/globals/_typography.scss
@@ -8,6 +8,8 @@
 @use "sass:map";
 @use "sass:list";
 
+@use "variables" as *;
+
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 // TYPE SCALE MAP
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -220,7 +222,7 @@ $type-scale: (
 	// Tablet overrides (768px+).
 	// Only emits a CSS variable if the value is non-null in the map,
 	// so sizes that don't change at tablet produce no output.
-	@media (min-width: 768px) {
+	@media (min-width: $size-md) {
 		:root {
 			@each $key, $config in $scale {
 				$fs: map.get($config, "tablet");
@@ -239,7 +241,7 @@ $type-scale: (
 
 	// Desktop overrides (1024px+).
 	// Same pattern as tablet — only non-null values are emitted.
-	@media (min-width: 1024px) {
+	@media (min-width: $size-lg) {
 		:root {
 			@each $key, $config in $scale {
 				$fs: map.get($config, "desktop");

--- a/assets/css/globals/_variables.scss
+++ b/assets/css/globals/_variables.scss
@@ -1,0 +1,22 @@
+/*
+Mobile nav starts at 600px - no variable as far as I can see - hard coded
+*/
+
+$size-sm: 640px;
+$size-md: 768px;
+$size-lg: 1024px;
+$size-xl: 1280px;
+$size-xxl: 1536px;
+
+/// Fluid clamp generator
+/// @param $min - minimum size (e.g. 16px)
+/// @param $max - maximum size (e.g. 40px)
+/// @param $vmin - minimum viewport (e.g. 768px)
+/// @param $vmax - maximum viewport (e.g. 1536px)
+
+@mixin fluid($property, $min, $max, $vmin, $vmax) {
+	$slope: calc(($max - $min) / ($vmax - $vmin)) * 100;
+	$intercept: $min - calc($slope * $vmin / 100);
+
+	#{$property}: clamp(#{$min}, #{$intercept} + #{$slope}vw, #{$max});
+}

--- a/assets/css/globals/_wordpress.scss
+++ b/assets/css/globals/_wordpress.scss
@@ -1,6 +1,10 @@
 :root {
 	/* WordPress-specific Design Tokens */
-	--wp-block-gap: var(--spacing-6);
+	--wp-block-gap: clamp(
+		16px,
+		8px + 1.0417vw,
+		40px
+	); //16px at 768px, 40px at 1536px
 	--wp-container-padding: var(--spacing-4);
 	--wp-editor-width: var(--size-content);
 	--wp-wide-width: var(--size-wide);

--- a/assets/css/globals/_wordpress.scss
+++ b/assets/css/globals/_wordpress.scss
@@ -1,10 +1,8 @@
+@use "variables" as *;
+
 :root {
 	/* WordPress-specific Design Tokens */
-	--wp-block-gap: clamp(
-		16px,
-		8px + 1.0417vw,
-		40px
-	); //16px at 768px, 40px at 1536px
+	@include fluid(--wp-block-gap, 16px, 40px, $size-md, $size-xxl);
 	--wp-container-padding: var(--spacing-4);
 	--wp-editor-width: var(--size-content);
 	--wp-wide-width: var(--size-wide);
@@ -27,7 +25,7 @@
 }
 
 /* Responsive WordPress adjustments */
-@media (min-width: 768px) {
+@media (min-width: $size-md) {
 	@theme {
 		--wp-container-padding: var(--spacing-6);
 		--wp-block-gap: var(--spacing-8);

--- a/theme.json
+++ b/theme.json
@@ -157,13 +157,7 @@
 			"text": "var(--colour-foreground)"
 		},
 		"spacing": {
-			"blockGap": "var(--wp-block-gap)",
-			"padding": {
-				"top": "0",
-				"bottom": "0",
-				"left": "var(--wp-container-padding)",
-				"right": "var(--wp-container-padding)"
-			}
+			"blockGap": "var(--wp-block-gap)"
 		},
 		"typography": {
 			"fontFamily": "var(--font-family-pt-sans)",


### PR DESCRIPTION
The gutter declaration in `theme.json` wasn't being pulled through.  Removed this and put it in a CSS file.

Added a new mixin to create a fluid clamp which gradually changes the numerical output based on screen width.  Used to apply gutter size and block gap.  

Fixed a bug with SCSS variables, applied the SCSS variables to all media queries instead of hard-coding things.