### PR TITLE
Root background colours

### DIFF
--- a/assets/css/globals/_header&footer.scss
+++ b/assets/css/globals/_header&footer.scss
@@ -106,3 +106,12 @@ footer {
 		border: 1px solid var(--colour-header-foreground);
 	}
 }
+
+:root {
+	background-color: var(--colour-root-background);
+
+	.editor-styles-wrapper {
+		// The editor screen always wants the page background, not the root background
+		background-color: var(--colour-page-background);
+	}
+}

--- a/assets/css/printing/_colours.scss
+++ b/assets/css/printing/_colours.scss
@@ -38,6 +38,7 @@
 	:root {
 		//colours - if undeclared, light mode shall be used
 		--colour-page-background: #fff;
+		--colour-root-background: #fff;
 		--colour-foreground: #000;
 
 		--colour-header-background: #fff;

--- a/assets/css/style-variations/_index.scss
+++ b/assets/css/style-variations/_index.scss
@@ -30,10 +30,10 @@ $palette-colour-list:
 
 //other colours
 $other-colour-list:
-	page-background, foreground, foreground-hint, disabled, muted, subtle, strong,
-	error, error-muted, focus-text, focus-background, focus-background-muted,
-	focus-outline, header-background, header-foreground, header-nav-background,
-	header-nav-background-overflow, header-nav-links,
+	root-background, page-background, foreground, foreground-hint, disabled,
+	muted, subtle, strong, error, error-muted, focus-text, focus-background,
+	focus-background-muted, focus-outline, header-background, header-foreground,
+	header-nav-background, header-nav-background-overflow, header-nav-links,
 	header-nav-drawer-background, header-nav-drawer-links,
 	header-nav-separator-line, header-button-background, header-button-foreground,
 	header-button-outline, header-search-form-background, header-search-form-text,

--- a/assets/css/style-variations/palettes/_cjsm.scss
+++ b/assets/css/style-variations/palettes/_cjsm.scss
@@ -48,6 +48,6 @@
 	--focus-background-muted--light-mode: #f8f4e4; //also needs to contrast with focus-text
 
 	// Beneath footer (root background colour)
-	--root-background-colour--light-mode: var(--palette-1--light-mode);
-	--root-background-colour--dark-mode: var(--palette-3--dark-mode);
+	// As the footer uses wb-force-dark, we don't set a dark mode here
+	--root-background--light-mode: var(--palette-1--light-mode);
 }

--- a/assets/css/style-variations/palettes/_cjsm.scss
+++ b/assets/css/style-variations/palettes/_cjsm.scss
@@ -46,4 +46,8 @@
 	// Focus colours
 	// dark mode uses light mode colours by default
 	--focus-background-muted--light-mode: #f8f4e4; //also needs to contrast with focus-text
+
+	// Beneath footer (root background colour)
+	--root-background-colour--light-mode: var(--palette-1--light-mode);
+	--root-background-colour--dark-mode: var(--palette-3--dark-mode);
 }

--- a/assets/css/style-variations/palettes/_defaults.scss
+++ b/assets/css/style-variations/palettes/_defaults.scss
@@ -100,7 +100,7 @@
 	--quote-border--light-mode: #737373; // At the moment, this block might be designed differently, so this might go
 
 	// Root background colour (visible beneath footer on short pages)
-	--root-background-colour--light-mode: var(--palette-greyscale-1--light-mode);
+	--root-background--light-mode: var(--palette-greyscale-1--light-mode);
 
 	// WB Block colours
 	// Reference other colours, rather than create new ones
@@ -213,5 +213,5 @@
 	--quote-border--dark-mode: #8c8c8c; // At the moment, this block might be designed differently, so this might go
 
 	// Root background colour (visible beneath footer on short pages)
-	--root-background-colour--dark-mode: var(--palette-greyscale-1--dark-mode);
+	--root-background--dark-mode: var(--palette-greyscale-1--dark-mode);
 }

--- a/assets/css/style-variations/palettes/_defaults.scss
+++ b/assets/css/style-variations/palettes/_defaults.scss
@@ -99,6 +99,9 @@
 	--link-text-visited--light-mode: #8200db;
 	--quote-border--light-mode: #737373; // At the moment, this block might be designed differently, so this might go
 
+	// Root background colour (visible beneath footer on short pages)
+	--root-background-colour--light-mode: var(--palette-greyscale-1--light-mode);
+
 	// WB Block colours
 	// Reference other colours, rather than create new ones
 	--wb-accordion-hover-bg: var(--colour-subtle);
@@ -208,4 +211,9 @@
 	--link-text-hover--dark-mode: #9fd0ff;
 	--link-text-visited--dark-mode: #c4a2d1;
 	--quote-border--dark-mode: #8c8c8c; // At the moment, this block might be designed differently, so this might go
+
+
+	// Root background colour (visible beneath footer on short pages)
+	--root-background-colour--dark-mode: var(--palette-greyscale-1--dark-mode);
+
 }

--- a/assets/css/style-variations/palettes/_defaults.scss
+++ b/assets/css/style-variations/palettes/_defaults.scss
@@ -212,8 +212,6 @@
 	--link-text-visited--dark-mode: #c4a2d1;
 	--quote-border--dark-mode: #8c8c8c; // At the moment, this block might be designed differently, so this might go
 
-
 	// Root background colour (visible beneath footer on short pages)
 	--root-background-colour--dark-mode: var(--palette-greyscale-1--dark-mode);
-
 }


### PR DESCRIPTION
Added the root background colour to the site.

(This is the colour which will appear beneath the footer should a page be short enough for this to be visible.)  

Default: Greyscale 1 for each mode.
CJSM: Colour 1 for light mode, default for dark mode (becasue the footer is force-dark)
Printing: use white
Editor screen, use page background colour