### PR TITLE
Footer pattern centre

### DIFF
--- a/patterns/footer-0-default.php
+++ b/patterns/footer-0-default.php
@@ -95,8 +95,8 @@
 		<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"fontSize":"sm","layout":{"type":"flex","orientation":"vertical","justifyContent":"left","flexWrap":"wrap"}} -->
 		<div class="wp-block-group has-sm-font-size">
 			<!-- wp:wb-blocks/hmg-svg {"logo":"ogl"} /-->
-			<!-- wp:paragraph {"align":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|text"}}}},"textColor":"text"} -->
-			<p class="has-text-align-center has-text-color has-link-color">All content is available under the&nbsp;<a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Open Government Licence v3.0</a>, except where otherwise stated</p>
+			<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|text"}}}},"textColor":"text"} -->
+			<p class="has-text-color has-link-color">All content is available under the&nbsp;<a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Open Government Licence v3.0</a>, except where otherwise stated</p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:group -->

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Govwind
 Text Domain: govwind
-Version: 2.0.0
+Version: 1.0.1
 Description: Full Site Editing (FSE) block theme, styled with a Tailwind & SCSS frontend
 Author: Ministry Of Justice
 Author URI: https://www.gov.uk/government/organisations/ministry-of-justice


### PR DESCRIPTION
Removed the centre alignment for the footer pattern OGL bit.  

New version is 1.0.1 - previous release was 1.0.0 (not 2.0.0 as was erroneously in the codebase).  