### PR TITLE
Fix/wp70 iframed editor styles

### DIFF
--- a/assets/js/editor-iframe-class.js
+++ b/assets/js/editor-iframe-class.js
@@ -3,7 +3,7 @@
  * allows the site-specific colours to be used.
  *
  * Vars:
- * - siteData (from functions.php), which has "name" (the sanitized site name) 
+ * - siteData (from functions.php), which has "name" (the sanitized site name)
  * and "id" (the blog ID).
  */
 

--- a/assets/js/editor-iframe-class.js
+++ b/assets/js/editor-iframe-class.js
@@ -3,8 +3,8 @@
  * allows the site-specific colours to be used.
  *
  * Vars:
- * - siteData (from functions.php), which only has "name" which the site
- * name, already sanitized for use in the class.
+ * - siteData (from functions.php), which has "name" (the sanitized site name) 
+ * and "id" (the blog ID).
  */
 
 wp.domReady(() => {

--- a/functions.php
+++ b/functions.php
@@ -170,11 +170,19 @@ add_action("enqueue_block_editor_assets", function () {
 	$site_name = sanitize_title(get_bloginfo("name")); // convert to safe CSS class
 	$site_ID = get_current_blog_id();
 
+	// Only load JS if file exists
+	$js_file = get_template_directory() . "/assets/js/editor-iframe-class.js";
+	if (!file_exists($js_file)) {
+		return;
+	}
+
+	$js_version = filemtime($js_file);
+
 	wp_enqueue_script(
 		"editor-iframe-class",
 		get_template_directory_uri() . "/assets/js/editor-iframe-class.js",
 		["wp-dom-ready", "wp-edit-post"],
-		filemtime(get_template_directory() . "/assets/js/editor-iframe-class.js"),
+		$js_version,
 		true,
 	);
 

--- a/functions.php
+++ b/functions.php
@@ -65,19 +65,6 @@ function govwind_enqueue_assets()
 }
 add_action("wp_enqueue_scripts", "govwind_enqueue_assets");
 
-// Enhanced editor styles support
-add_action("enqueue_block_editor_assets", function () {
-	$css_file = get_template_directory() . "/dist/style.css";
-	$css_version = file_exists($css_file) ? filemtime($css_file) : "1.0.0";
-
-	wp_enqueue_style(
-		"govwind-editor-style",
-		get_template_directory_uri() . "/dist/style.css",
-		[],
-		$css_version,
-	);
-});
-
 // Register custom block categories
 function govwind_register_block_categories($categories)
 {
@@ -177,23 +164,17 @@ function govwind_add_block_editor_class($classes)
  * the colour-picker palette are correct for the site.
  *
  * Outputs for the JS file:
- * - siteData, which only has "name" which the sanitized site name.
+ * - siteData, which has "name" (the sanitized site name) and "id" (the blog ID).
  */
 add_action("enqueue_block_editor_assets", function () {
 	$site_name = sanitize_title(get_bloginfo("name")); // convert to safe CSS class
 	$site_ID = get_current_blog_id();
 
-	// Only affects the block editor pages (and only really affects the colour picker palette)
-	$screen = get_current_screen();
-	if ($screen && $screen->is_block_editor()) {
-		echo "<script>document.documentElement.classList.add('website-$site_ID');</script>";
-	}
-
 	wp_enqueue_script(
 		"editor-iframe-class",
 		get_template_directory_uri() . "/assets/js/editor-iframe-class.js",
 		["wp-dom-ready", "wp-edit-post"],
-		false,
+		filemtime(get_template_directory() . "/assets/js/editor-iframe-class.js"),
 		true,
 	);
 
@@ -202,6 +183,16 @@ add_action("enqueue_block_editor_assets", function () {
 		"name" => $site_name,
 		"id" => $site_ID,
 	]);
+
+	// Only affects the block editor pages (and only really affects the colour picker palette)
+	$screen = get_current_screen();
+	if ($screen && $screen->is_block_editor()) {
+		wp_add_inline_script(
+			"editor-iframe-class",
+			"document.documentElement.classList.add('website-$site_ID');",
+			"before",
+		);
+	}
 });
 
 /**

--- a/inc/languages.php
+++ b/inc/languages.php
@@ -53,7 +53,7 @@ add_action("init", function () {
 add_action("enqueue_block_editor_assets", function () {
 	$screen = get_current_screen();
 
-	if ($screen && $screen->post_type !== "page") {
+	if (!$screen || $screen->post_type !== "page") {
 		return;
 	}
 

--- a/patterns/nav-side.php
+++ b/patterns/nav-side.php
@@ -46,7 +46,13 @@ if ($show_header_menu == "yes") {
 	];
 	?>
 	<!-- wp:group {"tagName":"nav"} -->
-	<nav class="wp-block-group" id="header-navigation" role="navigation" aria-label="Primary navigation" data-more-text="<?php echo esc_attr($more_text); ?>">
+	<nav
+		class="wp-block-group"
+		id="header-navigation"
+		role="navigation"
+		aria-label="Primary navigation"
+		data-more-text="<?php echo esc_attr($more_text); ?>"
+	>
         <?php
 	/*
 		<button type="button" class="hale-header__mobile-controls hale-header__mobile-controls--menu govuk-header__menu-button govuk-js-header-toggle" aria-controls="menu-menu-top-menu" aria-label="Show or hide navigation menu" hidden>

--- a/patterns/nav-top.php
+++ b/patterns/nav-top.php
@@ -54,7 +54,13 @@ if ($show_header_menu == "yes") {
 	//}
 	?>
     <!-- /wp:navigation -->
-    <nav class="wp-block-group col-start-2" id="header-navigation" role="navigation" aria-label="Primary navigation" data-more-text="<?php echo esc_attr($more_text); ?>">
+    <nav 
+		class="wp-block-group col-start-2"
+		id="header-navigation"
+		role="navigation"
+		aria-label="Primary navigation"
+		data-more-text="<?php echo esc_attr($more_text); ?>"
+	>
         <?php wp_nav_menu($topmenu_args); ?>
     </nav>
 <?php

--- a/patterns/nav-top.php
+++ b/patterns/nav-top.php
@@ -54,7 +54,7 @@ if ($show_header_menu == "yes") {
 	//}
 	?>
     <!-- /wp:navigation -->
-    <nav 
+    <nav
 		class="wp-block-group col-start-2"
 		id="header-navigation"
 		role="navigation"

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Govwind
 Text Domain: govwind
-Version: 1.0.2
+Version: 1.0.3
 Description: Full Site Editing (FSE) block theme, styled with a Tailwind & SCSS frontend
 Author: Ministry Of Justice
 Author URI: https://www.gov.uk/government/organisations/ministry-of-justice

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Govwind
 Text Domain: govwind
-Version: 1.0.3
+Version: 1.0.4
 Description: Full Site Editing (FSE) block theme, styled with a Tailwind & SCSS frontend
 Author: Ministry Of Justice
 Author URI: https://www.gov.uk/government/organisations/ministry-of-justice


### PR DESCRIPTION
This PR:

- Uses wp_add_inline_script  instead of echo
- Adds cache busting to iframe script
- Updates a comment for accuracy
- Fixes a bug in boolean logic
- Re-applies delete of `// Enhanced editor styles support ...` from https://github.com/ministryofjustice/govwind/commit/a43200d