### PR TITLE
Add explicit permissions to prettier workflow

### DIFF
--- a/.github/workflows/prettier-format.yml
+++ b/.github/workflows/prettier-format.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   check-prettier:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds explicit permissions instead of using GitHub defaults.

I this been tested by branching off and creating a PR where prettier intentionally fails.

We saw that the comment is successfully posted on the PR.

https://github.com/ministryofjustice/govwind/pull/142