### PR TITLE
Bump GovWind version to 1.0.3

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Govwind
 Text Domain: govwind
-Version: 1.0.2
+Version: 1.0.3
 Description: Full Site Editing (FSE) block theme, styled with a Tailwind & SCSS frontend
 Author: Ministry Of Justice
 Author URI: https://www.gov.uk/government/organisations/ministry-of-justice


### PR DESCRIPTION
Bumps the GovWind theme version to 1.0.3 in ready for a new release.

This release includes the recently merged npm dependency updates:

brace-expansion 1.1.12 → 1.1.18
immutable 5.1.3 → 5.1.9
picomatch 2.3.1 → 2.3.2
shell-quote 1.8.3 → 1.10.0
tar 7.5.9 → 7.5.22

Changes
Updated the GovWind version in style.css from the previous version to 1.0.3.